### PR TITLE
fix: removed redundant train-test split cell #6

### DIFF
--- a/CreditCardModel.ipynb
+++ b/CreditCardModel.ipynb
@@ -879,16 +879,6 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "id": "c685cbc2-f114-49b2-a091-ccc312cbf464",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42, stratify=y)"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 14,
    "id": "c868f4c0-85cd-45e5-9ddb-b9deea996362",
    "metadata": {},


### PR DESCRIPTION
Hello! I have removed the duplicate train-test split cell (Cell 13) as requested in issue #6. This cleans up the notebook and ensures the split logic is only executed once. I've also cleared the notebook outputs to ensure a clean commit.